### PR TITLE
Shift behavior swap.

### DIFF
--- a/octoprint_multilineterminal/static/js/multilineterminal.js
+++ b/octoprint_multilineterminal/static/js/multilineterminal.js
@@ -92,18 +92,13 @@ $(function() {
 				self.terminalViewModel.getHistoryMultiLine(-1);
 				return false;
 			}
-			if (event.shiftKey && self.terminalViewModel.multiLineRows() == 1 && event.keyCode === 13) {
-				self.terminalViewModel.multiLineRows(self.terminalViewModel.multiLineRows()+1);
-				return true;
-			}
-			if (event.keyCode === 13 && self.terminalViewModel.multiLineRows() > 1) {
-				if(self.terminalViewModel.multiLineRows() <= self.terminalViewModel.multiLineInputRowCount()){
-					self.terminalViewModel.multiLineRows(self.terminalViewModel.multiLineRows()+1);
+			if (event.keyCode === 13){ // handle Enter
+				if (!event.shiftKey){  // sending without Shift
+					$('#terminal-send').trigger('click');
+					return false;
 				}
-			}
-			if ((event.shiftKey || self.terminalViewModel.multiLineRows() == 1) && event.keyCode === 13) {
-				$('#terminal-send').trigger('click');
-				return false;
+				self.terminalViewModel.multiLineRows(self.terminalViewModel.multiLineRows()+1);  // adding line with Shift
+				return true;
 			}
 			if (event.keyCode === 8 && (self.terminalViewModel.multiLineRows() !== self.terminalViewModel.multiLineInputRowCount())){
 				self.terminalViewModel.multiLineRows(self.terminalViewModel.multiLineInputRowCount());


### PR DESCRIPTION
When in multi-line mode, swap the behaviors of Enter and Shift+Enter. This makes multi-line mode, match the behavior of single-line mode.

Also removed a check that used to protect against making new lines when multiLineInputRowCount > multiLineRows As far as i understand, that condition can't happen. Can it?